### PR TITLE
[29기 이강일] Kakao API 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ augmentor.py
 IMAGE/
 backup/
 .idea
+upload.sh
+backup/
+.idea
 
 # Created by https://www.toptal.com/developers/gitignore/api/pycharm,macos,linux,visualstudiocode,python,zsh,vim
 # Edit at https://www.toptal.com/developers/gitignore?templates=pycharm,macos,linux,visualstudiocode,python,zsh,vim

--- a/core/utils.py
+++ b/core/utils.py
@@ -1,0 +1,29 @@
+import requests
+
+class KakaoAPI:
+    def __init__(self, auth_code, REDIRECT_URI, KAKAO_API_KEY):
+        self.auth_code      = auth_code
+        self.redirect_uri   = REDIRECT_URI
+        self.rest_api_key   = KAKAO_API_KEY
+        self.grant_type     = "authorization_code"
+        self.token_url      = "https://kauth.kakao.com/oauth/token?grant_type={0}&client_id={1}&redirect_uri={2}&code={3}"\
+            .format(
+                    self.grant_type,
+                    self.rest_api_key,
+                    self.redirect_uri,
+                    self.auth_code
+                )
+        self.access_token   = self.get_token()
+        
+    def get_token(self):
+        headers        = {'Content-Type' : 'application/x-www-form-urlencoded'}
+        response       = requests.post(self.token_url, headers = headers)
+        access_token   = response.json()['access_token']
+        
+        return access_token
+    
+    def get_user(self):
+        headers      = {"Authorization" : f"Bearer {self.access_token}"}
+        response     = requests.get("https://kapi.kakao.com/v2/user/me", headers = headers, timeout = 3)
+
+        return response.json()

--- a/gream/settings.py
+++ b/gream/settings.py
@@ -12,14 +12,18 @@ https://docs.djangoproject.com/en/4.0/ref/settings/
 import pymysql
 
 from pathlib import Path
-from my_settings import SECRET_KEY, DATABASES
+from my_settings import SECRET_KEY, DATABASES, ALGORITHM, REDIRECT_URI, KAKAO_API_KEY
 
 pymysql.install_as_MySQLdb()
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
+KAKAO_API_KEY = KAKAO_API_KEY
 
+REDIRECT_URI = REDIRECT_URI
+
+ALGORITHM = ALGORITHM
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.0/howto/deployment/checklist/
 
@@ -31,8 +35,6 @@ SECRET_KEY = SECRET_KEY
 DEBUG = True
 
 ALLOWED_HOSTS = ['*']
-
-
 
 # Application definition
 
@@ -133,6 +135,10 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 APPEND_SLASH = False
 
+CORS_ORIGIN_ALLOW_ALL = True
+
+CORS_ALLOW_CREDENTIALS = True
+
 CORS_ALLOW_METHODS = (
     'DELETE',
     'GET',
@@ -141,7 +147,7 @@ CORS_ALLOW_METHODS = (
     'POST',
     'PUT',
 )
-    
+
 CORS_ALLOW_HEADERS = (
     'accept',
     'accept-encoding',
@@ -151,5 +157,5 @@ CORS_ALLOW_HEADERS = (
     'origin',
     'user-agent',
     'x-csrftoken',
-    'x-requested-with',    		
+    'x-requested-with',
 )

--- a/gream/urls.py
+++ b/gream/urls.py
@@ -14,8 +14,8 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 
-from django.urls import path
+from django.urls import path, include
 
 urlpatterns = [
-
+    path('users', include('users.urls'))
 ]

--- a/users/tests.py
+++ b/users/tests.py
@@ -1,3 +1,47 @@
-from django.test import TestCase
+import jwt
 
-# Create your tests here.
+from datetime      import datetime, timedelta
+
+from django.conf   import settings
+from django.test   import TestCase, Client
+from unittest.mock import patch, MagicMock
+
+from .models       import *
+
+class KakaoLoginTest(TestCase):
+    def setUp(self):
+        pass
+    @patch('core.utils.requests')
+    def test_kakao_login_success(self, mocked_requests):
+        client = Client()
+
+        class MockedResponse:
+            def json(self):
+
+                return {
+                    "id":1,
+                    "kakao_account": { 
+                        "profile_needs_agreement": False,
+                        "profile": {
+                            "nickname": "홍길동",
+                            "thumbnail_image_url": "http://yyy.kakao.com/.../img_110x110.jpg",
+                            "profile_image_url": "http://yyy.kakao.com/dn/.../img_640x640.jpg",
+                            "is_default_image": False
+                        },
+                        "email_needs_agreement":False,
+                        "is_email_valid": True,
+                        "is_email_verified": True, 
+                        "email": "sample@sample.com",
+                        "age_range_needs_agreement":False,
+                        "age_range":"20~29",
+                        "birthday_needs_agreement":False,
+                        "birthday":"1130"
+                        }
+                    }
+        mocked_requests.get = MagicMock(return_value = MockedResponse())
+        headers             = {"Authorization": "access_token"}
+        response            = client.get("/users/login", **headers)
+        access_token        = jwt.encode({'user_id' : 1,'exp': datetime.utcnow() + timedelta(days=1)}, settings.SECRET_KEY, settings.ALGORITHM)
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json(), {'message' : "SUCCESS", 'access_token' : access_token})

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,0 +1,7 @@
+from nturl2path import url2pathname
+from django.urls import path
+from users.views import KakaoLoginView
+
+urlpatterns = [
+    path('/login', KakaoLoginView.as_view()),
+]

--- a/users/views.py
+++ b/users/views.py
@@ -1,3 +1,38 @@
-from django.shortcuts import render
+import jwt
 
-# Create your views here.
+from datetime import datetime, timedelta
+
+from django.http  import JsonResponse
+from django.views import View
+from django.conf  import settings
+
+from core.utils   import KakaoAPI
+from users.models import User
+
+class KakaoLoginView(View):
+   def get(self, request):
+        try:
+            auth_code      = request.GET.get('code')
+            kakao_user     = KakaoAPI(auth_code, settings.REDIRECT_URI, settings.KAKAO_API_KEY).get_user()
+            kakao_id       = kakao_user['id']
+            email          = kakao_user['kakao_account']['email']
+            name           = kakao_user['kakao_account']['profile']['nickname']
+
+            user, created  = User.objects.get_or_create(
+                kakao    = kakao_id,
+                email    = email,
+                nickname = name
+            )
+            status_code    = 201 if created else 200
+            access_token   = jwt.encode(
+                {
+                'user_id' : user.id,
+                'exp'     : datetime.utcnow() + timedelta(days=1)
+                },
+                settings.SECRET_KEY,
+                settings.ALGORITHM
+            )
+            return JsonResponse({'message' : "SUCCESS", 'access_token' : access_token}, status = status_code)
+
+        except KeyError:
+            return JsonResponse({'message' : 'KEY_ERROR'}, status = 400)


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [x] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)

- 프론트에서 넘겨주는 인가코드을 이용해서 카카오 서버와 통신 후 토큰 발급

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

1. 프론트에서 주는 인가코드로 카카오에게 토큰을 받은 후 gream만의 서버 토큰을 재 생성 후 프론트에게 돌려줍니다.
- 만료 시간 설정 (1일)

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)

- 소셜 로그인 기능을 만들면서 프론트, 로그인 기능 제공 서버, 백이 어떻게 주고받는지 이해하게되었습니다.

<br />

## :: 기타 질문 및 특이 사항

